### PR TITLE
feat: New issue format with single rule table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5694,14 +5694,6 @@
       "resolved": "https://registry.npmjs.org/probot-metadata/-/probot-metadata-1.0.1.tgz",
       "integrity": "sha512-wpxBFHJMGd2xn18Bb+lKBZKCJ2/jboa8S8rKj5p5jsi6T3KRQPc54GLTrbSBMoSjbpGZnXwf9yUmJEKDc/w4+w=="
     },
-    "probot-scheduler": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/probot-scheduler/-/probot-scheduler-2.0.0-beta.1.tgz",
-      "integrity": "sha512-s22q0+Y+OzdV1f/i0wJw3QkgFSNV5glEBkB7C3aeV1jO3R6J02WqcDGjmJXlRz6XHb8eW9Rg9B9NLHfGR1GJpg==",
-      "requires": {
-        "bottleneck": "^2.0.1"
-      }
-    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "p-map-series": "^2.1.0",
     "probot": "^9.11.3",
     "probot-metadata": "^1.0.1",
-    "probot-scheduler": "^2.0.0-beta.1",
     "ramda": "^0.27.0",
     "source-map-support": "^0.5.16"
   },

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -8,6 +8,7 @@ import {
   fetchRepoTopics,
   issueTemplateExists,
   transposeTopicCorrections,
+  getConfig,
 } from './helpers'
 import { AppConfig, CheckResult, AllCheckResults } from './types'
 
@@ -15,7 +16,7 @@ export function checkDescription(
   context: Context,
   appConfig: AppConfig,
 ): CheckResult {
-  const config = appConfig.checks.description
+  const config = getConfig('description', appConfig)
   if (config.disabled) return result(config)
   const description = context.payload.repository.description
   const passed = description !== null && description.length > 0
@@ -26,7 +27,7 @@ export async function checkReadmeFile(
   context: Context,
   appConfig: AppConfig,
 ): Promise<CheckResult> {
-  const config = appConfig.checks.readmeFile
+  const config = getConfig('readmeFile', appConfig)
   if (config.disabled) return result(config)
   const file = await fetchFile(context, 'README.md')
   const passed = file && file.size >= config.size ? true : false
@@ -37,7 +38,7 @@ export async function checkLicenseFile(
   context: Context,
   appConfig: AppConfig,
 ): Promise<CheckResult> {
-  const config = appConfig.checks.licenseFile
+  const config = getConfig('licenseFile', appConfig)
   if (config.disabled) return result(config)
   const license = context.payload.repository.license
   // license == null: No LICENSE file
@@ -49,7 +50,7 @@ export async function checkLicense(
   context: Context,
   appConfig: AppConfig,
 ): Promise<CheckResult> {
-  const config = appConfig.checks.license
+  const config = getConfig('license', appConfig)
   if (config.disabled) return result(config)
   const license = context.payload.repository.license
   // license == null: No LICENSE file
@@ -65,7 +66,7 @@ export async function checkSupportFile(
   context: Context,
   appConfig: AppConfig,
 ): Promise<CheckResult> {
-  const config = appConfig.checks.supportFile
+  const config = getConfig('supportFile', appConfig)
   if (config.disabled) return result(config)
   const file = await fetchFile(context, 'SUPPORT.md')
   const passed = file && file.size >= config.size ? true : false
@@ -76,7 +77,7 @@ export function checkRepoName(
   context: Context,
   appConfig: AppConfig,
 ): CheckResult {
-  const config = appConfig.checks.repoName
+  const config = getConfig('repoName', appConfig)
   if (config.disabled) return result(config)
   const passed = context.payload.repository.name.length > config.length
   return result(config, passed)
@@ -86,7 +87,7 @@ export async function checkContributingFile(
   context: Context,
   appConfig: AppConfig,
 ): Promise<CheckResult> {
-  const config = appConfig.checks.contributingFile
+  const config = getConfig('contributingFile', appConfig)
   if (config.disabled) return result(config)
   const file = await fetchFile(context, 'CONTRIBUTING.md')
   const passed = file && file.size >= config.size ? true : false
@@ -97,7 +98,7 @@ export async function checkTopics(
   context: Context,
   appConfig: AppConfig,
 ): Promise<CheckResult> {
-  const config = appConfig.checks.topics
+  const config = getConfig('topics', appConfig)
   if (config.disabled) return result(config)
   // Fetch topics for repo
   const repo = context.payload.repository
@@ -131,7 +132,7 @@ export async function checkCustomTemplates(
   context: Context,
   appConfig: AppConfig,
 ): Promise<CheckResult> {
-  const config = appConfig.checks.customTemplates
+  const config = getConfig('customTemplates', appConfig)
   if (config.disabled) return result(config)
   const issueTemplatePassed = await issueTemplateExists(context)
   const pullRequestTemplate = await fetchFile(
@@ -146,7 +147,7 @@ export async function checkCodeOfConductFile(
   context: Context,
   appConfig: AppConfig,
 ): Promise<CheckResult> {
-  const config = appConfig.checks.codeOfConductFile
+  const config = getConfig('codeOfConductFile', appConfig)
   if (config.disabled) return result(config)
   const file = await fetchFile(context, 'CODE_OF_CONDUCT.md')
   const passed = file && file.size >= config.size ? true : false

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,110 +1,123 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 require('source-map-support').install()
-import { Application } from 'probot'
-import createScheduler from 'probot-scheduler'
+import { Application, Context } from 'probot'
+import R from 'ramda'
 
 import { defaultConfig } from './config'
 import { performChecks } from './checks'
-import { checkStatus, issueMessage } from './messages'
+import { checkStatus, issueMessage, issueTitle } from './messages'
 import {
   isActivePublicRepo,
-  fetchPreviousScore,
-  setScore,
+  fetchPreviousState,
+  setState,
   sortResultsByValue,
   refreshRepo,
+  fetchAppInfo,
+  generateState,
+  changesMessage,
 } from './helpers'
-import { AppConfig } from './types'
-import { sendMessage, hashMessage, findMessage } from './issue'
+import { AppConfig, State } from './types'
+import {
+  createUpdateIssueBody,
+  findMessage,
+  closeIssue,
+  createComment,
+} from './issue'
 
-// Default interval is every 12 hours (12 * 60 * 60 * 1000 = 43200000)
-const INTERVAL = parseInt(process.env.INTERVAL || '43200000')
+async function main(app: Application, context: Context) {
+  // Authenticate the app to get the name, url, and slug
+  const appInfo = await fetchAppInfo(app)
+  // Get the latest information on this repo
+  context.payload.repository = await refreshRepo(context)
+  // Don't check private or other non-relevant repos
+  if (!isActivePublicRepo(context)) return
+  // Read configuration
+  const config = (await context.config(
+    'community_health_assessment.yml',
+    defaultConfig,
+  )) as AppConfig
+
+  // Perform checks
+  const resultsUnsorted = await performChecks(context, config)
+  const results = sortResultsByValue(resultsUnsorted)
+
+  const issue = await findMessage(context, appInfo.appSlug)
+
+  if (results.score >= config.threshold) {
+    if (!issue) return
+    context.log.info(
+      `Repo changed from problems to success, closing issue: ${context.payload.repository.full_name}`,
+    )
+    closeIssue(context, appInfo, issue, results)
+    return
+  }
+
+  let previousState: State | undefined
+  if (issue) {
+    previousState = await fetchPreviousState(context, issue)
+
+    if (R.equals(previousState, generateState(results))) {
+      context.log.info(
+        `Changes needed on repo (${context.payload.repository.full_name}), but same state (score:${results.score}) as last time, do nothing`,
+      )
+      return
+    }
+  }
+
+  // Log what will be done
+  context.log.info(
+    `Changes needed on repo, ${issue ? 'updating' : 'creating'} issue: ${
+      context.payload.repository.full_name
+    }`,
+  )
+
+  const message = await createUpdateIssueBody(
+    context,
+    appInfo,
+    issueTitle,
+    `${issueMessage}\n${checkStatus(results)}`,
+    {
+      issue,
+    },
+  )
+  await setState(results, context, {
+    owner: message.owner,
+    repo: message.repo,
+    number: message.issue,
+  })
+  // Create comment with what changed
+  if (issue && previousState) {
+    await createComment(
+      context,
+      appInfo,
+      changesMessage(results, previousState),
+      { issue },
+    )
+  }
+}
 
 export = (app: Application): void => {
-  createScheduler(app, { interval: INTERVAL })
-  app.on('schedule.repository', async (context) => {
-    // Get the latest information on this repo
-    context.payload.repository = await refreshRepo(context)
-    // Don't check private or other non-relevant repos
-    if (!isActivePublicRepo(context)) return
-    // Read configuration
-    const config = (await context.config(
-      'community_health_assessment.yml',
-      defaultConfig,
-    )) as AppConfig
-
-    // Perform checks
-    const resultsUnsorted = await performChecks(context, config)
-    const results = sortResultsByValue(resultsUnsorted)
-
-    const issueTitle = '[Community Health Assessment] Changes needed'
-    const hash = hashMessage(issueTitle)
-
-    const issue = await findMessage(app, context, hash)
-
-    if (issue) {
-      const previousScore = await fetchPreviousScore(context, issue)
-
-      if (results.score === previousScore) {
-        context.log.info(
-          `Changes needed on repo (${context.payload.repository.full_name}), but same score (${results.score}) as last time, do nothing`,
-        )
-        return
-      }
-    }
-
-    if (results.score < config.threshold) {
-      // Open an issue to report results and request changes
-      if (issue) {
-        context.log.info(
-          `Changes needed on repo, updating issue: ${context.payload.repository.full_name}`,
-        )
-      } else {
-        context.log.info(
-          `Changes needed on repo, creating issue: ${context.payload.repository.full_name}`,
-        )
-      }
-      const message = await sendMessage(
-        app,
-        context,
-        `[Community Health Assessment] Changes needed`,
-        issueMessage,
-        {
-          update: checkStatus(results),
-          updateAfterDays: 0,
-          issue,
-          hash,
-        },
-      )
-      await setScore(results.score, context, {
-        owner: message.owner,
-        repo: message.repo,
-        number: message.issue,
-      })
-    } else {
-      if (issue) {
-        context.log.info(
-          `Repo changed from problems to success, closing issue: ${context.payload.repository.full_name}`,
-        )
-        const message = await sendMessage(
-          app,
-          context,
-          `[Community Health Assessment] Changes needed`,
-          issueMessage,
-          {
-            update:
-              checkStatus(results) +
-              `\n\n:tada: Congratulations! This repo has met the community health requirements! :tada:`,
-            updateAfterDays: 0,
-            issue,
-            hash,
-          },
-        )
-        context.github.issues.update({
-          ...context.repo(),
-          issue_number: message.issue,
-          state: 'closed',
-        })
-      }
-    }
+  app.on(
+    [
+      'repository.edited',
+      'repository.renamed',
+      'repository.publicized',
+      'star.created',
+      'fork',
+      'watch',
+    ],
+    async (context) => {
+      if (context.payload.repository.private) return
+      return await main(app, context)
+    },
+  )
+  app.on('push', async (context) => {
+    if (context.payload.repository.private) return
+    if (
+      context.payload.ref !==
+      `refs/heads/${context.payload.repository.default_branch}`
+    )
+      return
+    return await main(app, context)
   })
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -2,10 +2,14 @@ import Handlebars from 'handlebars'
 
 export const issueMessage = `This issue was opened by a bot called [{appName}]({appUrl}) because this repo has failed too many community health checks.
 
-**Repo maintainers:** Please take the time to fix these issues to reach the target score. These improvements will help others find your work and contribute to it. This issue will update as your score improves until it hits the target score.
+**Repo maintainers:** Please take the time to fix the issues in the table to reach the target score. These improvements will help others find your work and contribute to it. This issue will update as your score improves until it hits the target score.
 
-**See the comments below** for information on which health checks need attention.
+Click **More info** for instructions to fix each item.
 `
+
+export const issueTitle = '[Community Health Assessment] Changes needed'
+
+export const closeMessage = `:tada: Congratulations! This repo has met the community health requirements! :tada:`
 
 export const checkStatus = Handlebars.compile(
   `

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,38 +1,68 @@
+export interface AppInfo {
+  appName: string
+  appUrl: string
+  appSlug: string
+}
+
 export interface PrimaryCheckConfig {
+  id?: CheckId
   disabled: boolean
   name: string
   value: number
   infoLink: string
 }
 
+export type DescriptionConfig = PrimaryCheckConfig
+export type ReadmeFileConfig = PrimaryCheckConfig & { size: number }
+export type LicenseFileConfig = PrimaryCheckConfig
+export type LicenseConfig = PrimaryCheckConfig & { licenses: string[] | null }
+export type SupportFileConfig = PrimaryCheckConfig & { size: number }
+export type RepoNameConfig = PrimaryCheckConfig & { length: number }
+export type ContributingFileConfig = PrimaryCheckConfig & { size: number }
+export type TopicsConfig = PrimaryCheckConfig & {
+  requiredTopic: string[]
+  topicCorrections: {
+    [topic: string]: string[]
+  }
+}
+export type CustomTemplatesConfig = PrimaryCheckConfig
+export type CodeOfConductFileConfig = PrimaryCheckConfig & { size: number }
+
+export type AnyCheckConfig =
+  | DescriptionConfig
+  | ReadmeFileConfig
+  | LicenseFileConfig
+  | LicenseConfig
+  | SupportFileConfig
+  | RepoNameConfig
+  | ContributingFileConfig
+  | TopicsConfig
+  | CustomTemplatesConfig
+  | CodeOfConductFileConfig
+
+export type CheckId =
+  | 'description'
+  | 'readmeFile'
+  | 'licenseFile'
+  | 'license'
+  | 'supportFile'
+  | 'repoName'
+  | 'contributingFile'
+  | 'topics'
+  | 'customTemplates'
+  | 'codeOfConductFile'
+
 export interface ChecksConfig {
-  description: PrimaryCheckConfig
-  readmeFile: PrimaryCheckConfig & {
-    size: number
-  }
-  licenseFile: PrimaryCheckConfig
-  license: PrimaryCheckConfig & {
-    licenses: string[] | null
-  }
-  supportFile: PrimaryCheckConfig & {
-    size: number
-  }
-  repoName: PrimaryCheckConfig & {
-    length: number
-  }
-  contributingFile: PrimaryCheckConfig & {
-    size: number
-  }
-  topics: PrimaryCheckConfig & {
-    requiredTopic: string[]
-    topicCorrections: {
-      [topic: string]: string[]
-    }
-  }
-  customTemplates: PrimaryCheckConfig
-  codeOfConductFile: PrimaryCheckConfig & {
-    size: number
-  }
+  description: DescriptionConfig
+  readmeFile: ReadmeFileConfig
+  licenseFile: LicenseFileConfig
+  license: LicenseConfig
+  supportFile: SupportFileConfig
+  repoName: RepoNameConfig
+  contributingFile: ContributingFileConfig
+  topics: TopicsConfig
+  customTemplates: CustomTemplatesConfig
+  codeOfConductFile: CodeOfConductFileConfig
 }
 
 export interface AppConfig {
@@ -41,6 +71,7 @@ export interface AppConfig {
 }
 
 export interface CheckResult {
+  id: CheckId
   name: string
   passed: boolean
   score: number
@@ -55,3 +86,18 @@ export interface AllCheckResults {
   total: number
   threshold: number
 }
+
+export interface CheckState {
+  id: CheckId
+  passed: boolean
+  score: number
+  skipped?: boolean
+}
+
+export interface State {
+  checks: CheckState[]
+  score: number
+  threshold: number
+}
+
+export type CheckStateIndex = { [id in CheckId]: CheckState }

--- a/test/checks.test.ts
+++ b/test/checks.test.ts
@@ -4,7 +4,8 @@ import myProbotApp from '../src'
 import { Probot, Context } from 'probot'
 import { createApp, createConfig } from './test-helpers'
 // Requiring our fixtures
-import payload from './fixtures/schedule.repository.json'
+import payload from './fixtures/repository.edited.json'
+
 import licenseOther from './fixtures/license-other.json'
 import licenseISC from './fixtures/license-isc.json'
 import {
@@ -103,7 +104,7 @@ describe('Health checks', () => {
       const config = createConfig('readmeFile')
 
       nock('https://api.github.com')
-        .get('/repos/my-org/testing-things/contents/README.md')
+        .get('/repos/my-org/my-repo/contents/README.md')
         .reply(200, {
           type: 'file',
           size: 1,
@@ -120,7 +121,7 @@ describe('Health checks', () => {
       const config = createConfig('readmeFile')
 
       nock('https://api.github.com')
-        .get('/repos/my-org/testing-things/contents/README.md')
+        .get('/repos/my-org/my-repo/contents/README.md')
         .reply(200, {
           type: 'file',
           size: 200,
@@ -231,7 +232,7 @@ describe('Health checks', () => {
       const config = createConfig('topics', { requiredTopic: ['required1'] })
 
       nock('https://api.github.com')
-        .get('/repos/my-org/testing-things/topics')
+        .get('/repos/my-org/my-repo/topics')
         .reply(200, { names: ['topic1', 'topic2', 'topic3'] })
 
       const result = await checkTopics(context, config)
@@ -243,7 +244,7 @@ describe('Health checks', () => {
       const config = createConfig('topics', { requiredTopic: ['required1'] })
 
       nock('https://api.github.com')
-        .get('/repos/my-org/testing-things/topics')
+        .get('/repos/my-org/my-repo/topics')
         .reply(200, { names: ['required1', 'topic2', 'topic3'] })
 
       const result = await checkTopics(context, config)

--- a/test/fixtures/app.json
+++ b/test/fixtures/app.json
@@ -1,0 +1,20 @@
+{
+  "id": 123,
+  "slug": "octoapp",
+  "owner": {
+    "login": "github",
+    "id": 1
+  },
+  "name": "Octocat App",
+  "description": "",
+  "external_url": "https://example.com",
+  "html_url": "https://github.com/apps/octoapp",
+  "permissions": {
+    "metadata": "read",
+    "contents": "read",
+    "issues": "write",
+    "single_file": "write"
+  },
+  "events": ["push", "pull_request"],
+  "installations_count": 3
+}

--- a/test/fixtures/repository.edited.json
+++ b/test/fixtures/repository.edited.json
@@ -1,17 +1,22 @@
 {
-  "action": "repository",
+  "action": "edited",
+  "changes": {
+    "description": {
+      "from": null
+    }
+  },
   "installation": {
     "id": 2
   },
   "repository": {
-    "name": "testing-things",
+    "name": "my-repo",
     "private": false,
     "owner": {
       "login": "my-org"
     },
     "description": "Test repo",
     "fork": false,
-    "full_name": "my-org/testing-things",
+    "full_name": "my-org/my-repo",
     "homepage": "https://example.com",
     "language": "Python",
     "archived": false,

--- a/test/fixtures/sort-results.ts
+++ b/test/fixtures/sort-results.ts
@@ -1,6 +1,9 @@
-export const unsortedResultsFixture = {
+import { AllCheckResults } from '../../src/types'
+
+export const unsortedResultsFixture: AllCheckResults = {
   checks: [
     {
+      id: 'description',
       name: 'check1',
       passed: true,
       score: 10,
@@ -9,6 +12,7 @@ export const unsortedResultsFixture = {
       skipped: false,
     },
     {
+      id: 'readmeFile',
       name: 'check2',
       passed: true,
       score: 10,
@@ -17,6 +21,7 @@ export const unsortedResultsFixture = {
       skipped: false,
     },
     {
+      id: 'supportFile',
       name: 'check3',
       passed: false,
       score: 0,
@@ -29,9 +34,10 @@ export const unsortedResultsFixture = {
   total: 500,
   threshold: 400,
 }
-export const sortedResultsFixture = {
+export const sortedResultsFixture: AllCheckResults = {
   checks: [
     {
+      id: 'supportFile',
       name: 'check3',
       passed: false,
       score: 0,
@@ -40,6 +46,7 @@ export const sortedResultsFixture = {
       skipped: false,
     },
     {
+      id: 'readmeFile',
       name: 'check2',
       passed: true,
       score: 10,
@@ -48,6 +55,7 @@ export const sortedResultsFixture = {
       skipped: false,
     },
     {
+      id: 'description',
       name: 'check1',
       passed: true,
       score: 10,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,7 +3,8 @@ import nock from 'nock'
 import myProbotApp from '../src'
 import { Probot } from 'probot'
 // Requiring our fixtures
-import payload from './fixtures/schedule.repository.json'
+import payload from './fixtures/repository.edited.json'
+import appPayload from './fixtures/app.json'
 const fs = require('fs')
 const path = require('path')
 
@@ -30,7 +31,7 @@ describe('Community Health App', () => {
 
   beforeEach(() => {
     nock.disableNetConnect()
-    probot = new Probot({ id: 123, cert: mockCert, githubToken: 'test' })
+    probot = new Probot({ id: 3, cert: mockCert, githubToken: 'test' })
     // Load our app into probot
     probot.load(myProbotApp)
   })
@@ -43,14 +44,16 @@ describe('Community Health App', () => {
       .get('/app/installations?per_page=100')
       .reply(200, [])
 
+    nock('https://api.github.com').get('/app').reply(200, appPayload)
+
     // Refresh repo details first
     nock('https://api.github.com')
-      .get('/repos/my-org/testing-things')
+      .get('/repos/my-org/my-repo')
       .reply(200, payload.repository)
 
     nock('https://api.github.com')
       .get(
-        '/repos/my-org/testing-things/contents/.github/community_health_assessment.yml',
+        '/repos/my-org/my-repo/contents/.github/community_health_assessment.yml',
       )
       .reply(200, {})
       .get(
@@ -63,7 +66,7 @@ describe('Community Health App', () => {
       .reply(200, {})
 
     // Receive a webhook event
-    await probot.receive({ name: 'schedule', payload })
+    await probot.receive({ name: 'repository', payload })
   })
 
   afterEach(() => {


### PR DESCRIPTION

Previously the rule table showed up in each comment which meant
maintainers had to scroll to the bottom of the issue to get the latest
status. With this change, the current table is always in the issue body,
and a trail of comments indicates the changes to that table and the score.